### PR TITLE
docs: fix README content issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build](https://github.com/ballerina-platform/module-ballerinax-hubspot.crm.engagements.communications/actions/workflows/ci.yml/badge.svg)](https://github.com/ballerina-platform/module-ballerinax-hubspot.crm.engagements.communications/actions/workflows/ci.yml)
 [![GitHub Last Commit](https://img.shields.io/github/last-commit/ballerina-platform/module-ballerinax-hubspot.crm.engagements.communications.svg)](https://github.com/ballerina-platform/module-ballerinax-hubspot.crm.engagements.communications/commits/master)
-[![GitHub Issues](https://img.shields.io/github/issues/ballerina-platform/ballerina-library/module/hubspot.crm.engagements.communications.svg?label=Open%20Issues)](https://github.com/ballerina-platform/ballerina-library/labels/module%hubspot.crm.engagements.communications)
+[![GitHub Issues](https://img.shields.io/github/issues/ballerina-platform/ballerina-library/module/hubspot.crm.engagements.communications.svg?label=Open%20Issues)](https://github.com/ballerina-platform/ballerina-library/labels/module%2Fhubspot.crm.engagements.communications)
 
 ## Overview
 
@@ -115,7 +115,7 @@ Before proceeding with the Quickstart, ensure you have obtained the Access Token
 
 ## Quickstart
 
-To use the `Hubspot CRM Engagements Communications` connector in your Ballerina application, update the `.bal` file as follows:
+To use the `HubSpot CRM Engagements Communications` connector in your Ballerina application, update the `.bal` file as follows:
 
 ### Step 1: Import the module
 

--- a/ballerina/README.md
+++ b/ballerina/README.md
@@ -116,7 +116,7 @@ Before proceeding with the Quickstart, ensure you have obtained the Access Token
 
 ## Quickstart
 
-To use the `Hubspot CRM Engagements Communications` connector in your Ballerina application, update the `.bal` file as follows:
+To use the `HubSpot CRM Engagements Communications` connector in your Ballerina application, update the `.bal` file as follows:
 
 ### Step 1: Import the module
 


### PR DESCRIPTION
## Purpose

Fixes documentation issues identified in the HubSpot connector audit (README-only changes for this repo).

Changes:
- Replace `Hubspot` with `HubSpot` (brand-name occurrences only) in both the top-level `README.md` and the package-level `ballerina/README.md`.
- Fix encoding in the GitHub Issues badge URL in `README.md` (`module%hubspot...` -> `module%2Fhubspot...`) so the badge link resolves to the correct label page.

Refs ballerina-platform/ballerina-library#8823

## Examples

N/A - documentation-only change.

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility